### PR TITLE
Remove scheduled CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ on:
   pull_request:
     branches:
      - master
-  schedule:
-    - cron: '0 7 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
We constantly get CI failures due to some unknown site setup error. Until this is fixed properly, we remove scheduled CI runs to reduce noise.