### PR TITLE
Explicitly require all dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "php": "^8.0",
         "typo3/cms-core": "^10.4 || ^11.5 || ^12.4",
         "typo3/cms-extbase": "^10.4 || ^11.5 || ^12.4",
-        "psr/http-client": "^1.0"
+        "psr/http-client": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
         "codeception/codeception": "^4.0 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "psr/http-message": "^1.0 || ^2.0",
         "psr/http-server-middleware": "^1.0",
         "psr/http-server-handler": "^1.0",
-        "psr/log": "^1.0 || ^2.0 || ^3.0"
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
+        "symfony/console": "^5.4 || ^6.4"
     },
     "require-dev": {
         "codeception/codeception": "^4.0 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,15 @@
     ],
     "require": {
         "php": "^8.0",
-        "typo3/cms-core": "^10.4 || ^11.5 || ^12.4",
-        "typo3/cms-extbase": "^10.4 || ^11.5 || ^12.4",
         "psr/http-client": "^1.0",
+        "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0 || ^2.0",
-        "psr/http-server-middleware": "^1.0",
         "psr/http-server-handler": "^1.0",
+        "psr/http-server-middleware": "^1.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/console": "^5.4 || ^6.4",
-        "psr/http-factory": "^1.0"
+        "typo3/cms-core": "^10.4 || ^11.5 || ^12.4",
+        "typo3/cms-extbase": "^10.4 || ^11.5 || ^12.4"
     },
     "require-dev": {
         "codeception/codeception": "^4.0 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "require": {
         "php": "^8.0",
         "typo3/cms-core": "^10.4 || ^11.5 || ^12.4",
-        "typo3/cms-extbase": "^10.4 || ^11.5 || ^12.4"
+        "typo3/cms-extbase": "^10.4 || ^11.5 || ^12.4",
+        "psr/http-client": "^1.0"
     },
     "require-dev": {
         "codeception/codeception": "^4.0 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "typo3/cms-extbase": "^10.4 || ^11.5 || ^12.4",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0 || ^2.0",
-        "psr/http-server-middleware": "^1.0"
+        "psr/http-server-middleware": "^1.0",
+        "psr/http-server-handler": "^1.0"
     },
     "require-dev": {
         "codeception/codeception": "^4.0 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0 || ^2.0",
         "psr/http-server-middleware": "^1.0",
-        "psr/http-server-handler": "^1.0"
+        "psr/http-server-handler": "^1.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "codeception/codeception": "^4.0 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "psr/http-server-middleware": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "symfony/console": "^5.4 || ^6.4"
+        "symfony/console": "^5.4 || ^6.4",
+        "psr/http-factory": "^1.0"
     },
     "require-dev": {
         "codeception/codeception": "^4.0 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "typo3/cms-core": "^10.4 || ^11.5 || ^12.4",
         "typo3/cms-extbase": "^10.4 || ^11.5 || ^12.4",
         "psr/http-client": "^1.0",
-        "psr/http-message": "^1.0 || ^2.0"
+        "psr/http-message": "^1.0 || ^2.0",
+        "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
         "codeception/codeception": "^4.0 || ^5.0",


### PR DESCRIPTION
Using https://packagist.org/packages/maglnet/composer-require-checker

```
$ composer-require-checker check composer.json
ComposerRequireChecker 4.7.1@e49c58b18fef21e37941a642c1a70d3962e86f28
The following 18 unknown symbols were found:
+--------------------------------------------------+--------------------+
| Unknown Symbol                                   | Guessed Dependency |
+--------------------------------------------------+--------------------+
| opcache_get_status                               | ext-Zend OPcache   |
| Psr\Http\Client\ClientInterface                  |                    |
| Psr\Http\Message\RequestFactoryInterface         |                    |
| Psr\Http\Message\RequestInterface                |                    |
| Psr\Http\Message\ResponseFactoryInterface        |                    |
| Psr\Http\Message\ResponseInterface               |                    |
| Psr\Http\Message\ServerRequestInterface          |                    |
| Psr\Http\Server\MiddlewareInterface              |                    |
| Psr\Http\Server\RequestHandlerInterface          |                    |
| Psr\Log\LoggerAwareInterface                     |                    |
| Psr\Log\LoggerAwareTrait                         |                    |
| Symfony\Component\Console\Command\Command        |                    |
| Symfony\Component\Console\Helper\Table           |                    |
| Symfony\Component\Console\Helper\TableCell       |                    |
| Symfony\Component\Console\Helper\TableCellStyle  |                    |
| Symfony\Component\Console\Helper\TableSeparator  |                    |
| Symfony\Component\Console\Input\InputInterface   |                    |
| Symfony\Component\Console\Output\OutputInterface |                    |
+--------------------------------------------------+--------------------+
```

(`ext-Zend` is skipped for now.)