### PR TITLE
Drop helhum/typo3-console 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "codeception/module-cli": "^2.0",
         "ergebnis/composer-normalize": "^2.3",
         "friendsofphp/php-cs-fixer": "^3.41",
-        "helhum/typo3-console": "^6.0 || ^7.0 || ^8.0",
+        "helhum/typo3-console": "^7.0 || ^8.0",
         "php-parallel-lint/php-console-highlighter": "^1.0.0",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "phpstan/phpstan": "^1.0.0",


### PR DESCRIPTION
This was necessary for TYPO3v10.